### PR TITLE
feat: conditionally render account nav item

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -21,12 +21,12 @@ export function MainNav({ userRole }: MainNavProps) {
   const isDesigner = userRole === "designer"
 
   const navItems = [
-    ...(isClient 
+    ...(isClient
       ? [
           { name: "Dashboard", href: "/client/dashboard" },
           { name: "New Request", href: "/client/new-request" },
           { name: "My Requests", href: "/client/requests" },
-        ] 
+        ]
       : []),
     ...(isDesigner
       ? [
@@ -35,8 +35,8 @@ export function MainNav({ userRole }: MainNavProps) {
           { name: "My Work", href: "/designer/my-work" },
         ]
       : []),
-    { name: "Account", href: `/${userRole}/account` },
-  ]
+    ...(userRole ? [{ name: "Account", href: `/${userRole}/account` }] : []),
+  ] satisfies Array<{ name: string; href: string }>
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">


### PR DESCRIPTION
## Summary
- render the Account link only when userRole is provided
- enforce nav item URLs are always defined

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities, Parsing error: ';' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a4173be194832181de1a73a36dd042