### PR TITLE
feat: improve thermometer accessibility

### DIFF
--- a/components/thermometer-display.tsx
+++ b/components/thermometer-display.tsx
@@ -28,23 +28,35 @@ export function ThermometerDisplay({ data }: ThermometerDisplayProps) {
     <div className="space-y-3">
       <div className="relative pt-6">
         {/* Thermometer visual */}
-        <div className="relative h-24 w-8 mx-auto bg-muted rounded-full overflow-hidden border">
-          <div 
+        <div
+          className="relative h-24 w-8 mx-auto bg-muted rounded-full overflow-hidden border"
+          role="progressbar"
+          aria-valuenow={Math.round(progress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-describedby="thermometer-progress-label"
+        >
+          <div
             className={`absolute bottom-0 w-full transition-all duration-1000 ${getColorClass()}`}
             style={{ height: `${progress}%` }}
           />
-          <div 
-            className="absolute bottom-0 left-0 right-0 h-3 bg-red-600 dark:bg-red-800" 
+          <div
+            className="absolute bottom-0 left-0 right-0 h-3 bg-red-600 dark:bg-red-800"
             style={{ opacity: progress > 95 ? 1 : 0.3 }}
           />
         </div>
-        
+
         {/* Temperature circle */}
-        <div 
+        <div
+          aria-hidden="true"
           className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/3 h-10 w-10 rounded-full flex items-center justify-center text-white text-xs font-medium border-2 border-white dark:border-gray-800 transition-all ${getColorClass()}`}
         >
           {Math.round(progress)}%
         </div>
+
+        <span id="thermometer-progress-label" className="sr-only">
+          Request volume {Math.round(progress)}%
+        </span>
       </div>
       
       <Progress value={progress} className="h-2.5 w-full" />


### PR DESCRIPTION
## Summary
- add progressbar semantics and ARIA attributes to thermometer
- expose request volume percentage via screen reader text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `'` can be escaped warnings and parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68a4174689d88321939e8bf0ad053439