### PR TITLE
refactor: centralize request categories

### DIFF
--- a/app/client/new-request/page.tsx
+++ b/app/client/new-request/page.tsx
@@ -53,24 +53,12 @@ import {
 import { cn } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast"
 import { ThermometerDisplay } from "@/components/thermometer-display"
-import { RequestCategory } from "@/types"
-
-const requestCategories: RequestCategory[] = [
-  "Logo Design",
-  "Web Design",
-  "Social Media Graphics",
-  "Print Design",
-  "Brand Identity",
-  "UI/UX Design",
-  "Illustrations",
-  "Packaging Design",
-  "Other"
-];
+import { requestCategories } from "@/types/categories"
 
 const formSchema = z.object({
   title: z.string().min(4, { message: "Title must be at least 4 characters" }).max(100),
   description: z.string().min(10, { message: "Description must be at least 10 characters" }),
-  category: z.enum(requestCategories as [RequestCategory, ...RequestCategory[]]),
+  category: z.enum(requestCategories),
   deadline: z.date().min(new Date(), { message: "Deadline must be in the future" }),
   priority: z.enum(["low", "medium", "high", "urgent"])
 });
@@ -302,7 +290,7 @@ export default function NewRequestPage() {
                   <div>
                     <p className="font-medium mb-1">Your request volume is high</p>
                     <p className="text-xs">
-                      You've submitted several requests recently. You may experience slightly longer turnaround times.
+                      You&#39;ve submitted several requests recently. You may experience slightly longer turnaround times.
                     </p>
                   </div>
                 </div>

--- a/app/designer/requests/page.tsx
+++ b/app/designer/requests/page.tsx
@@ -35,7 +35,8 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
-import { DesignRequest, RequestCategory } from "@/types"
+import { DesignRequest } from "@/types"
+import { requestCategories as categories } from "@/types/categories"
 
 // Mock data
 const availableRequests: DesignRequest[] = [
@@ -101,17 +102,6 @@ const availableRequests: DesignRequest[] = [
   }
 ];
 
-const categories: RequestCategory[] = [
-  "Logo Design",
-  "Web Design",
-  "Social Media Graphics",
-  "Print Design",
-  "Brand Identity",
-  "UI/UX Design",
-  "Illustrations",
-  "Packaging Design",
-  "Other"
-];
 
 export default function DesignerRequestsPage() {
   const router = useRouter()

--- a/types/categories.ts
+++ b/types/categories.ts
@@ -1,0 +1,13 @@
+export const requestCategories = [
+  "Logo Design",
+  "Web Design",
+  "Social Media Graphics",
+  "Print Design",
+  "Brand Identity",
+  "UI/UX Design",
+  "Illustrations",
+  "Packaging Design",
+  "Other"
+] as const;
+
+export type RequestCategory = typeof requestCategories[number];

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,13 +1,6 @@
-export type RequestCategory = 
-  | "Logo Design"
-  | "Web Design"
-  | "Social Media Graphics"
-  | "Print Design"
-  | "Brand Identity"
-  | "UI/UX Design"
-  | "Illustrations"
-  | "Packaging Design"
-  | "Other";
+import type { RequestCategory } from "./categories";
+
+export type { RequestCategory } from "./categories";
 
 export type RequestStatus = 
   | "pending"


### PR DESCRIPTION
## Summary
- add shared `requestCategories` array
- use shared list in client and designer request pages
- re-export `RequestCategory` type from categories module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx next lint --file app/client/new-request/page.tsx --file app/designer/requests/page.tsx --file types/index.ts --file types/categories.ts`
- `npx tsc --noEmit` *(fails: app/designer/requests/[id]/page.tsx(1,8): error TS1005: ';' expected.)*


------
https://chatgpt.com/codex/tasks/task_e_68a41741cc908321b8f0b9ba2592dd96