### PR TITLE
fix: mark request list as client component

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import Link from "next/link"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"

--- a/components/request-list.tsx
+++ b/components/request-list.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from "next/link"
 import { format, isAfter } from "date-fns"
 import { Badge } from "@/components/ui/badge"


### PR DESCRIPTION
## Summary
- mark `RequestList` as a client component
- convert client dashboard page to a server component

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a41ac9f3d483219de6c724b8e9f4d1