### PR TITLE
fix: remove unused progress import causing build failure

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/toaster';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Design Studio Portal',
@@ -18,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} min-h-screen flex flex-col`}>
+      <body className="min-h-screen flex flex-col">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,28 +1,27 @@
-'use client';
+'use client'
 
-import * as React from 'react';
-import * as ProgressPrimitive from '@radix-ui/react-progress';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-import { cn } from '@/lib/utils';
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number
+}
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('relative h-4 w-full overflow-hidden rounded-full bg-secondary', className)}
+      {...props}
+    >
+      <div
+        className="h-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+)
 
-export { Progress };
+Progress.displayName = 'Progress'
+
+export { Progress }


### PR DESCRIPTION
## Summary
- replace Google font with system font to avoid build-time fetch
- simplify Progress component to avoid Radix runtime error
- remove unused Progress import from client dashboard

## Testing
- `npm run build` *(fails: Page "/designer/requests/[id]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.)*

------
https://chatgpt.com/codex/tasks/task_e_68a49ebc99688321a994dd2e3ba3f889