### PR TITLE
Refactor request page to server component

### DIFF
--- a/app/designer/requests/[id]/page.tsx
+++ b/app/designer/requests/[id]/page.tsx
@@ -1,7 +1,4 @@
-"use client"
-
-import { useEffect, useState } from "react"
-import { useParams } from "next/navigation"
+import { notFound } from "next/navigation"
 
 import type { DesignRequest } from "@/types"
 
@@ -41,29 +38,19 @@ async function fetchRequest(id: string): Promise<DesignRequest> {
   return request
 }
 
-export default function RequestPage() {
-  const { id } = useParams<{ id: string }>()
-  const [request, setRequest] = useState<DesignRequest | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+export async function generateStaticParams() {
+  return Object.keys(mockRequests).map((id) => ({ id }))
+}
 
-  useEffect(() => {
-    fetchRequest(id)
-      .then(setRequest)
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false))
-  }, [id])
-
-  if (loading) {
-    return <div className="p-4">Loading...</div>
-  }
-
-  if (error) {
-    return <div className="p-4 text-red-500">{error}</div>
-  }
+export default async function RequestPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const request = await fetchRequest(params.id).catch(() => null)
 
   if (!request) {
-    return <div className="p-4">No request found.</div>
+    notFound()
   }
 
   return (


### PR DESCRIPTION
## Summary
- convert designer request detail page to async server component
- generate static params from mock requests
- handle missing requests with notFound

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;` in app/client/dashboard/page.tsx`)*
- `npm run lint -- --file app/designer/requests/'[id]'/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5051c508321b4a2f6d18113dd52