### PR TITLE
docs: explain generateStaticParams for static export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # felks-client-portal
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/fehleques/felks-client-portal)
+
+## Static export and dynamic routes
+
+When using Next.js with `output: 'export'`, every dynamic route segment must define [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params). Without this function, `next build` cannot determine which paths to pre-render and the export will fail.
+
+```ts
+// app/posts/[slug]/page.tsx
+export async function generateStaticParams() {
+  return [
+    { slug: 'hello-world' },
+    { slug: 'another-post' },
+  ];
+}
+```
+
+This function supplies the parameter values used to generate the static HTML for each route.
+
+Before pushing changes, run `npm run build` locally. The build step surfaces missing `generateStaticParams` functions and other export issues early.


### PR DESCRIPTION
## Summary
- document that dynamic routes need `generateStaticParams` when using `output: 'export'`
- provide example of supplying params
- note to run `npm run build` locally to catch missing exports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error: `'` can be escaped with...)*
- `npm run build` *(fails: Page "/designer/requests/[id]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a509580c8321ad7128be92bf7af3