### PR TITLE
Handle request fetch errors in RequestPage

### DIFF
--- a/app/designer/requests/[id]/page.test.ts
+++ b/app/designer/requests/[id]/page.test.ts
@@ -1,0 +1,13 @@
+import { fetchRequest } from "./page"
+
+// Static type check to ensure the error path is handled correctly.
+async function checkErrorPath() {
+  try {
+    await fetchRequest("unknown-id")
+  } catch (err) {
+    const message: string = err instanceof Error ? err.message : ""
+    console.log(message)
+  }
+}
+
+checkErrorPath()

--- a/app/designer/requests/[id]/page.tsx
+++ b/app/designer/requests/[id]/page.tsx
@@ -32,13 +32,17 @@ const mockRequests: Record<string, DesignRequest> = {
   },
 }
 
-async function fetchRequest(id: string): Promise<DesignRequest> {
+export async function fetchRequest(id: string): Promise<DesignRequest> {
   await new Promise((resolve) => setTimeout(resolve, 300))
   const request = mockRequests[id]
   if (!request) {
     throw new Error("Request not found")
   }
   return request
+}
+
+function RequestError({ message }: { message: string }) {
+  return <div className="p-4 text-red-500">{message}</div>
 }
 
 export default function RequestPage() {
@@ -48,10 +52,19 @@ export default function RequestPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetchRequest(id)
-      .then(setRequest)
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false))
+    async function load() {
+      try {
+        const data = await fetchRequest(id)
+        setRequest(data)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load request"
+        setError(message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
   }, [id])
 
   if (loading) {
@@ -59,7 +72,7 @@ export default function RequestPage() {
   }
 
   if (error) {
-    return <div className="p-4 text-red-500">{error}</div>
+    return <RequestError message={error} />
   }
 
   if (!request) {


### PR DESCRIPTION
## Summary
- wrap `fetchRequest` in try/catch and expose a `RequestError` component for graceful failure handling
- add a static type-check test to validate the error path

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: `react/no-unescaped-entities` in app/client/dashboard/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a508e6588321bdcb8102a4030099