### PR TITLE
chore: target ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- target modern JS runtime by setting TypeScript `target` to `ES2020`
- adjust designer request page to support static export

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4c0533cdc8321838d362956739aa9