### PR TITLE
chore: enforce lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # felks-client-portal
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/fehleques/felks-client-portal)
+
+## Continuous Integration
+
+Run `npm run lint` to ensure code passes ESLint. This command should be included in CI workflows to catch lint errors before deployment.
+

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -139,7 +139,7 @@ export default function ClientDashboard() {
                 <div className="mt-4 p-3 bg-amber-100 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-xl flex items-start gap-2">
                   <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                   <p className="text-amber-800 dark:text-amber-300 text-xs">
-                    You're nearing your request limit. Consider spacing out new requests.
+                    You&apos;re nearing your request limit. Consider spacing out new requests.
                   </p>
                 </div>
               ) : null}

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: 'export',
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: { unoptimized: true },
 };


### PR DESCRIPTION
## Summary
- enforce ESLint during builds
- fix unescaped apostrophe warning
- document linting requirement for CI

## Testing
- `npm run lint`
- `npm run build` *(fails: Page "app/designer/requests/[id]/page.tsx" does not match the required types of a Next.js Page.  "fetchRequest" is not a valid Page export field.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c052fe748321b4ab6338aca76cb9